### PR TITLE
Update iana tz coord to 1.0.3

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,7 +16,7 @@ faaspact-verifier = "*"
 
 [packages]
 requests = "*"
-iana-tz-coord = ">=1.0.2"
+iana-tz-coord = ">=1.0.3"
 sentry-sdk = "*"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "892bdb68cb82f06ee29369dc3f7e0a5748dd1cd8bd9beb9de7f4a3cabbda5622"
+            "sha256": "b5c6e4d9ff704016864d7ba733bc78f0b0f5f79897580a7b3bb1c8be973ed1dd"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -32,11 +32,11 @@
         },
         "iana-tz-coord": {
             "hashes": [
-                "sha256:6b8f84c38f63cc9cdfa8ed2d9d97d0d6af9e1999627e3e4a5e71131060d8cdd9",
-                "sha256:f5aee0dcb9203da75a01a807e18392a0dfc2d20067dea2124c0c0e3e3cff7fdc"
+                "sha256:50031b31998593b58c3332a282f6a42c368df9e607690714ae48fc77c744705d",
+                "sha256:581a711fa102b7e90730bfa09c0b511db600d16a5e5d944f8f21738b45d28ff6"
             ],
             "index": "pypi",
-            "version": "==1.0.2"
+            "version": "==1.0.3"
         },
         "idna": {
             "hashes": [
@@ -237,11 +237,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:f689bf2fc18c4585403348dd56f47d87780bf217c53ed9ae7a3e2d7faa45f8e9",
-                "sha256:f812ea39a0153566be53d88f8de94839db1e8a05352ed8a49525d7d7f37861e9"
+                "sha256:3e65a22eb0d4f1bdbc1eacccf4a3198bf8d4049dea5112d70a0c61b00e748d02",
+                "sha256:5924060b374f62608a078494b909d341720a050b5224ff87e17e12377486a71d"
             ],
             "index": "pypi",
-            "version": "==4.0.2"
+            "version": "==4.1.0"
         },
         "pytest-hammertime": {
             "hashes": [

--- a/sunlight/gateways/geo_timezone/geo_timezone_test.py
+++ b/sunlight/gateways/geo_timezone/geo_timezone_test.py
@@ -10,3 +10,9 @@ def test_can_ignore_extra_iana_prefix() -> None:
 def test_can_fetch_montreal() -> None:
     gateway = GeoTimezoneGateway()
     gateway.fetch_timezone_coordinates('America/Montreal')
+
+
+def test_can_fetch_kolkata_as_calcutta() -> None:
+    gateway = GeoTimezoneGateway()
+    assert (gateway.fetch_timezone_coordinates('Asia/Kolkata') ==
+            gateway.fetch_timezone_coordinates('Asia/Calcutta'))


### PR DESCRIPTION
This was actually pretty interesting. The tz database has a whole mapping of current timezone names to backward compatible names. Shouldn't get anymore sentries about unknown timezones.

Unfortunately someone in calcutta tried to connect a few times the other day and failed 